### PR TITLE
New onPlant lifecycle to enable reuse of LogWriter resources

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -20,6 +20,12 @@ logger.i = function(tag, message) {
 logger.plant = function(writer) {
   // Note : do not remove plant give access to the caller to define logwriter.
   // todo : in future the logger api will accept more than one logwriter.
+  try {
+    writer.onPlant();
+  } catch (err) {
+    // fail silently but warn the user.
+    return;
+  }
   this._writer_ = writer;
 };
 
@@ -52,7 +58,11 @@ logger.t = function(tag, message) {
 
 
 logger.__write__ = function(level, tag, message) {
-  this._writer_.write(level, tag, message);
+  try {
+    this._writer_.write(level, tag, message);
+  } catch (err) {
+    // fail silently incase of writer exception. should use common available console printing
+  }
 };
 
 module.exports = logger;

--- a/src/logwriter.js
+++ b/src/logwriter.js
@@ -34,6 +34,6 @@ LogWriter.prototype.write = function(level, tag, message) {
 
 LogWriter.prototype.onPlant = function() {
   throw new Error('Not Implemented by LogWriter');
-}
+};
 
 module.exports = LogWriter;

--- a/src/logwriter.js
+++ b/src/logwriter.js
@@ -32,4 +32,8 @@ LogWriter.prototype.write = function(level, tag, message) {
   }
 };
 
+LogWriter.prototype.onPlant = function() {
+  throw new Error('Not Implemented by LogWriter');
+}
+
 module.exports = LogWriter;

--- a/src/mongowriter.js
+++ b/src/mongowriter.js
@@ -24,12 +24,12 @@ util.inherits(MongoWriter, LogWriter);
  */
 MongoWriter.prototype.open = function() {
   // should be called before setting logger#plant
-}
+};
 
 MongoWriter.prototype.onPlant = function() {
   // check if mongo is connected or throw error.
   throw new Error('Mongo connection should be established before planting the mongo log writer');
-}
+};
 
 /**
 * Mongo write method
@@ -56,6 +56,6 @@ MongoWriter.prototype.write = function(level, tag, message) {
 
 MongoWriter.prototype.close = function() {
   // close the db connection here.
-}
+};
 
 module.exports = MongoWriter;


### PR DESCRIPTION
Created blueprint of `onPlant` lifecycle for LogWriter to enable reusing LogWriter resources.

Also log messages should record timestamps, should use time formatting if node `Date` shows up ugly in mongo.
